### PR TITLE
fix: minor fix on replies of reviews

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,10 +6,14 @@
   <component name="ChangeListManager">
     <list default="true" id="f4135850-6277-4b40-86f8-bf6f59677566" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/communifilm/ai/MovieAgent.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/communifilm/ai/MovieAgent.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/communifilm/ai/MovieReviewTool.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/communifilm/ai/MovieReviewTool.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/communifilm/services/MovieAgentService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/communifilm/services/MovieAgentService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/communifilm/controllers/AgentController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/communifilm/controllers/AgentController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/communifilm/controllers/ReviewReplyController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/communifilm/controllers/ReviewReplyController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/communifilm/dtos/CreateReviewReplyDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/communifilm/dtos/CreateReviewReplyDto.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/communifilm/dtos/ReviewReplyResponseDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/communifilm/dtos/ReviewReplyResponseDto.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/communifilm/models/MovieReview.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/communifilm/models/MovieReview.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/communifilm/models/ReviewReply.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/communifilm/models/ReviewReply.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/communifilm/services/MovieReviewService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/communifilm/services/MovieReviewService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/communifilm/services/ReviewReplyService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/communifilm/services/ReviewReplyService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/resources/application.properties" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application.properties" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -61,7 +65,7 @@
     "RunOnceActivity.git.unshallow": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "Spring Boot.CommuniFilmApplication.executor": "Run",
-    "git-widget-placeholder": "issue-25",
+    "git-widget-placeholder": "minor-fix",
     "kotlin-language-version-configured": "true",
     "node.js.detected.package.eslint": "true",
     "node.js.detected.package.tslint": "true",

--- a/src/main/java/com/communifilm/controllers/AgentController.java
+++ b/src/main/java/com/communifilm/controllers/AgentController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
  * Provides endpoints for users to interact with the AI assistant.
  */
 @RestController
-@RequestMapping("/api/agent")
+@RequestMapping("/agent")
 @RequiredArgsConstructor
 @CrossOrigin(origins = "http://localhost:3000")
 @Slf4j

--- a/src/main/java/com/communifilm/controllers/ReviewReplyController.java
+++ b/src/main/java/com/communifilm/controllers/ReviewReplyController.java
@@ -4,14 +4,14 @@ import com.communifilm.dtos.CreateReviewReplyDto;
 import com.communifilm.dtos.ReviewReplyResponseDto;
 import com.communifilm.models.ReviewReply;
 import com.communifilm.services.ReviewReplyService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+@RestController
+@RequestMapping("/replies")
 public class ReviewReplyController {
     private ReviewReplyService reviewReplyService;
 
@@ -25,7 +25,7 @@ public class ReviewReplyController {
         return reviewReplyService.createReply(replyDto);
     }
 
-    @GetMapping("/replies/{reviewId}")
+    @GetMapping("/review/{reviewId}")
     public List<ReviewReplyResponseDto> getRepliesForReview(@PathVariable String reviewId) throws ExecutionException, InterruptedException{
         return reviewReplyService.getRepliesForReview(reviewId);
     }

--- a/src/main/java/com/communifilm/dtos/CreateReviewReplyDto.java
+++ b/src/main/java/com/communifilm/dtos/CreateReviewReplyDto.java
@@ -13,5 +13,6 @@ public class CreateReviewReplyDto {
     private String parentReviewId;
     private Long movieId;
     private String userId;
+    private String username;
     private String text;
 }

--- a/src/main/java/com/communifilm/dtos/ReviewReplyResponseDto.java
+++ b/src/main/java/com/communifilm/dtos/ReviewReplyResponseDto.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 @AllArgsConstructor
 public class ReviewReplyResponseDto {
     private String replyId;
+    private String parentReviewId;
     private String username;
     private String text;
     private Instant createdAt;

--- a/src/main/java/com/communifilm/models/MovieReview.java
+++ b/src/main/java/com/communifilm/models/MovieReview.java
@@ -16,6 +16,7 @@ public class MovieReview {
     private Long movieId;
     private String userId;
     private String text;
+    private Integer replyCount;
     private Instant createdAt;
     private Instant updatedAt;
 }

--- a/src/main/java/com/communifilm/models/ReviewReply.java
+++ b/src/main/java/com/communifilm/models/ReviewReply.java
@@ -15,6 +15,7 @@ public class ReviewReply{
     private String parentReviewId;
     private Long movieId;
     private String userId;
+    private String username;
     private String text;
     private Instant createdAt;
     private Instant updatedAt;

--- a/src/main/java/com/communifilm/services/MovieReviewService.java
+++ b/src/main/java/com/communifilm/services/MovieReviewService.java
@@ -15,9 +15,11 @@ import java.util.concurrent.ExecutionException;
 public class MovieReviewService {
 
     private final Firestore firestore;
+    private final ReviewReplyService reviewReplyService;
 
-    public MovieReviewService(Firestore firestore) {
+    public MovieReviewService(Firestore firestore, ReviewReplyService reviewReplyService) {
         this.firestore = firestore;
+        this.reviewReplyService = reviewReplyService;
     }
 
     public MovieReview createReview(CreateReviewDto reviewDto) throws ExecutionException, InterruptedException {
@@ -45,18 +47,32 @@ public class MovieReviewService {
 
     public List<MovieReview> getReviewsForMovie(Long movieId) throws ExecutionException, InterruptedException {
         List<MovieReview> reviews = new ArrayList<>();
-        List<QueryDocumentSnapshot> documents = firestore.collection("reviews").whereEqualTo("movieId", movieId).get().get().getDocuments();
+        List<QueryDocumentSnapshot> documents = firestore.collection("reviews")
+                .whereEqualTo("movieId", movieId)
+                .get()
+                .get()
+                .getDocuments();
+
         for (QueryDocumentSnapshot document : documents) {
-            reviews.add(document.toObject(MovieReview.class));
+            MovieReview review = document.toObject(MovieReview.class);
+            review.setReplyCount(reviewReplyService.countRepliesForReview(review.getReviewId()));
+            reviews.add(review);
         }
         return reviews;
     }
 
     public List<MovieReview> getReviewsForUser(String userId) throws ExecutionException, InterruptedException {
         List<MovieReview> reviews = new ArrayList<>();
-        List<QueryDocumentSnapshot> documents = firestore.collection("reviews").whereEqualTo("userId", userId).get().get().getDocuments();
+        List<QueryDocumentSnapshot> documents = firestore.collection("reviews")
+                .whereEqualTo("userId", userId)
+                .get()
+                .get()
+                .getDocuments();
+
         for (QueryDocumentSnapshot document : documents) {
-            reviews.add(document.toObject(MovieReview.class));
+            MovieReview review = document.toObject(MovieReview.class);
+            review.setReplyCount(reviewReplyService.countRepliesForReview(review.getReviewId()));
+            reviews.add(review);
         }
         return reviews;
     }

--- a/src/main/java/com/communifilm/services/ReviewReplyService.java
+++ b/src/main/java/com/communifilm/services/ReviewReplyService.java
@@ -28,6 +28,7 @@ public class ReviewReplyService {
         newReplyData.put("parentReviewId", replyDto.getParentReviewId());
         newReplyData.put("movieId", replyDto.getMovieId());
         newReplyData.put("userId", replyDto.getUserId());
+        newReplyData.put("username", replyDto.getUsername());
         newReplyData.put("text", replyDto.getText());
         newReplyData.put("createdAt", FieldValue.serverTimestamp());
         newReplyData.put("updatedAt", FieldValue.serverTimestamp());
@@ -55,7 +56,8 @@ public class ReviewReplyService {
             replies.add(
                     ReviewReplyResponseDto.builder()
                             .replyId(reply.getReplyId())
-                            .username(reply.getUserId())
+                            .parentReviewId(reply.getParentReviewId())
+                            .username(reply.getUsername())
                             .text(reply.getText())
                             .createdAt(reply.getCreatedAt())
                             .build()
@@ -63,5 +65,15 @@ public class ReviewReplyService {
         }
 
         return replies;
+    }
+
+    public int countRepliesForReview(String reviewId) throws ExecutionException, InterruptedException {
+        List<QueryDocumentSnapshot> documents = firestore.collection("reviewReplies")
+                .whereEqualTo("parentReviewId", reviewId)
+                .get()
+                .get()
+                .getDocuments();
+
+        return documents.size();
     }
 }


### PR DESCRIPTION
This pull request introduces enhancements to the movie review and reply system, primarily by adding support for tracking the number of replies to each review, improving the reply data model, and refining API endpoints for better clarity and usability. The changes affect both the data models and service/controller layers to support these new features.

**Enhancements to review and reply functionality:**

* The `MovieReview` model now includes a `replyCount` field, and both `getReviewsForMovie` and `getReviewsForUser` methods in `MovieReviewService` populate this field using a new `countRepliesForReview` method in `ReviewReplyService`. This allows the frontend to display how many replies each review has. 
* The `ReviewReply` and related DTOs (`CreateReviewReplyDto`, `ReviewReplyResponseDto`) now include a `username` and `parentReviewId` field, providing more context in reply data and improving the ability to display threaded conversations. 

**API and controller improvements:**

* The `ReviewReplyController` is now annotated as a `@RestController` with a base path of `/replies`, and the endpoint for fetching replies to a review is changed to `/review/{reviewId}` for clarity and RESTful design. 
